### PR TITLE
Force usage of GTK2 (to avoid linkage to system protobuf)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ ExternalProject_Add(opencv3_src
     -DWITH_TBB=ON
     -DBUILD_opencv_python2=ON
     -DBUILD_opencv_python3=OFF
+    -DWITH_GTK_2_X=ON  # Can't use GTK3 as it links against system protobuf.
     -DWITH_V4L=ON
     -DINSTALL_C_EXAMPLES=OFF
     -DINSTALL_PYTHON_EXAMPLES=OFF


### PR DESCRIPTION
We can't use GTK3 at the moment because:
```
$ ldd /usr/lib/x86_64-linux-gnu/libgtk-3.so | grep proto
libmirprotobuf.so.3 => /usr/lib/x86_64-linux-gnu/libmirprotobuf.so.3 (0x00007f869e651000)
libprotobuf-lite.so.9 => /home/eggerk/catkin_ws/devel/lib/libprotobuf-lite.so.9 (0x00007f869dd95000)
```
it links against system protobuf.